### PR TITLE
feat: add argument for specifying host address

### DIFF
--- a/src/arguments.rs
+++ b/src/arguments.rs
@@ -9,6 +9,10 @@ pub struct Args {
     #[arg(short, long, default_value = "9000")]
     port: u16,
 
+    /// The host address to bind to (e.g. "127.0.0.1" or "0.0.0.0")
+    #[arg(short = 'a', long, default_value = "127.0.0.1")]
+    host: String,
+
     /// The status code to return in the response
     #[arg(short, long, default_value = "200")]
     status_code: u16,
@@ -52,5 +56,9 @@ impl Args {
 
     pub const fn get_port(&self) -> u16 {
         self.port
+    }
+
+    pub fn get_host(&self) -> &str {
+        &self.host
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,7 +20,9 @@ async fn main() -> std::io::Result<()> {
     let args = Args::parse();
     let config = args.to_config();
 
-    let addr = SocketAddr::from(([127, 0, 0, 1], args.get_port()));
+    let host: std::net::IpAddr = args.get_host().parse()
+        .expect("Invalid host address");
+    let addr = SocketAddr::new(host, args.get_port());
     let listener = TcpListener::bind(addr).await?;
 
     println!("{} Listening on http://{}", "[Started]".green(), addr);


### PR DESCRIPTION
Adds `--host`/`-a` for specifying the address to host on. For example, `0.0.0.0` lets Docker containers connect through `http://host.docker.internal:9000`.

`-a` (for "address") was chosen over `-h` and `-H` since both of those have conflicts.